### PR TITLE
Support for "Tip" display added in phpstan v1.10.0

### DIFF
--- a/src/commands/analyse.ts
+++ b/src/commands/analyse.ts
@@ -1,6 +1,7 @@
 import { Ext } from "../extension";
 import {
   parsePHPStanAnalyseResult,
+  PHPStanAnalyseMessageItem,
   PHPStanAnalyseResult,
 } from "../utils/phpstan";
 import { killProcess, waitForClose } from "../utils/process";
@@ -14,6 +15,12 @@ function setStatusBarProgress(ext: Ext, progress?: number) {
   if (!!progress && progress > 0) text += ` (${progress}%)`;
 
   ext.setStatusBar({ text, command: showOutput });
+}
+
+function handleDiagnosticMessage(messageItem: PHPStanAnalyseMessageItem) {
+  return messageItem.tip
+    ? messageItem.message + "\n💡 " + messageItem.tip
+    : messageItem.message;
 }
 
 async function refreshDiagnostics(ext: Ext, result: PHPStanAnalyseResult) {
@@ -46,7 +53,7 @@ async function refreshDiagnostics(ext: Ext, result: PHPStanAnalyseResult) {
       const range = new Range(line, 0, line, 0);
       const diagnostic = new Diagnostic(
         range,
-        messageItem.message,
+        handleDiagnosticMessage(messageItem),
         DiagnosticSeverity.Error
       );
 

--- a/src/utils/phpstan.ts
+++ b/src/utils/phpstan.ts
@@ -9,14 +9,17 @@ export type PHPStanAnalyseResult = {
   files: {
     [path: string]: {
       errors: number;
-      messages: {
-        message: string;
-        line: number | null;
-        ignorable: boolean;
-      }[];
+      messages: PHPStanAnalyseMessageItem[];
     };
   };
   errors: string[];
+};
+
+export type PHPStanAnalyseMessageItem = {
+  message: string;
+  line: number | null;
+  ignorable: boolean;
+  tip?: string;
 };
 
 export type PHPStanConfig = {


### PR DESCRIPTION
PHPStan now displays a tip for errors from v1.10.0.
This helps developers by suggesting the cause of the problem.

For example, it is explained as follows.
https://phpstan.org/r/839f1fd2-d66a-4356-af21-3fe171d83fd1
(Lighbulb emoji in CLI, small grey text in online playground)

This pull request has been changed so that tip is displayed in Diagnostic.

If you want to change the message content, make changes to the handleDiagnosticMessage method.

The following image shows the tip that can now be displayed in this pull request and shows the same error as in the example above.

<img width="733" alt="" src="https://user-images.githubusercontent.com/30901083/228234652-b8a3ac77-b56d-46fe-a00d-8d4df40b30ac.png">